### PR TITLE
Hidden file support

### DIFF
--- a/src/spi-fat-fuse.c
+++ b/src/spi-fat-fuse.c
@@ -324,7 +324,6 @@ static int spi_fat_fuse_readdir(const char *path, void *buf, fuse_fill_dir_t fil
          * These are demangled in open() and getattr()
          */
         if ( finfo.fname[0] == '_' ) {
-            printf( "resource fork found: %s\n", finfo.fname );
             finfo.fname[0] = '.';
         }
 


### PR DESCRIPTION
Add support for hidden files. FatFS translates files starting with '.' to starting with '_'. Do the opposite here such that ls and ls -a do the right thing.